### PR TITLE
Add Semigroup instance for GHC 8.4 compatibility.

### DIFF
--- a/src/Proto3/Wire/Encode.hs
+++ b/src/Proto3/Wire/Encode.hs
@@ -108,7 +108,7 @@ import           Proto3.Wire.Types
 --
 -- Use `toLazyByteString` when you're done assembling the `MessageBuilder`
 newtype MessageBuilder = MessageBuilder { unMessageBuilder :: WB.Builder }
-  deriving Monoid
+  deriving (Semigroup, Monoid)
 
 instance Show MessageBuilder where
   showsPrec prec builder =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-7.4
+resolver: nightly-2018-05-18


### PR DESCRIPTION
Tested with `lts-7.4` and a `nightly` that uses GHC 8.4, which requires a `Semigroup` instance for `Monoid`.