### PR TITLE
Bump containers bounds for GHC 8.6 compatibility.

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -20,7 +20,7 @@ library
   build-depends:       base >=4.9 && <=5.0,
                        bytestring >=0.10.6.0 && <0.11.0,
                        cereal >= 0.5.1 && <0.6,
-                       containers ==0.5.*,
+                       containers >= 0.5 && <0.7,
                        deepseq ==1.4.*,
                        hashable <1.3,
                        safe ==0.3.*,


### PR DESCRIPTION
Nightlies, as of December, are coming with transformers 0.6.0.1. Gotta bump.